### PR TITLE
Add name demangling to perf section in README.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -99,7 +99,7 @@ This is the result from the [example data](http://linuxgazette.net/100/misc/vina
 ### Linux perf
 
     perf record -g -- /path/to/your/executable
-    perf script | gprof2dot.py -f perf | dot -Tpng -o output.png
+    perf script | c++filt | gprof2dot.py -f perf | dot -Tpng -o output.png
 
 ### oprofile
 


### PR DESCRIPTION
This fixes C++ mangled names in perf output.

At least on my system (Ubuntu 14.04, perf version 3.16.7-ckt16), all C++
names are mangled by default. Adding c++filt into the pipeline fixes
this.