### PR TITLE
fixed printing output on stdout in Python 3.5.1

### DIFF
--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -3214,7 +3214,10 @@ def main():
     profile = parser.parse()
 
     if options.output is None:
-        output = sys.stdout
+        if PYTHON_3:
+            output = open(1, 'w', encoding='utf-8', closefd=False)
+        else:
+            output = sys.stdout
     else:
         if PYTHON_3:
             output = open(options.output, 'wt', encoding='UTF-8')


### PR DESCRIPTION
This should close #21 

I realized that manual tests are needed, as printing on stdout is not covered by Travis test suite