### PR TITLE
Force relative import of debug file

### DIFF
--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -51,7 +51,7 @@ else:
 
 try:
     # Debugging helper module
-    import debug
+    from gprof2dot import debug
 except ImportError:
     pass
 


### PR DESCRIPTION
I was having an issue when launching gprof2dot in a virtual environment containing the [debug](https://pypi.python.org/pypi/debug/0.3.2) Python package.

When this package is installed, the `import debug` statement launches an interactive shell. Forcing the debug import to be relative fixed my issue.