### PR TITLE
Skip header '# callgrind format' if any. Closes #35.

### DIFF
--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -1647,6 +1647,11 @@ class CallgrindParser(LineParser):
         # read lookahead
         self.readline()
 
+        # read '# callgrind format' if any
+        callgrind_format = self.lookahead()
+        if callgrind_format != None and callgrind_format == '# callgrind format':
+            self.readline()
+
         self.parse_key('version')
         self.parse_key('creator')
         while self.parse_part():


### PR DESCRIPTION
See https://github.com/jrfonseca/gprof2dot/issues/35#issuecomment-330218808 and https://github.com/jrfonseca/gprof2dot/issues/35#issuecomment-330220057. I'm not sure if I did it correctly, but it looks like it works.