### PR TITLE
Deprecated: python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
 
         'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
 
-        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
Explicitly defined python 2.7 as only python2 supported version. Python 2.6 can't even show `--help`.