### PR TITLE
Avoid UnicodeEncodeError if system does not support Unicode

### DIFF
--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -55,6 +55,7 @@ else:
 
 
 MULTIPLICATION_SIGN = unichr(0xd7)
+ELLIPSIS = unichr(0x2026)
 
 
 def times(x):
@@ -3010,7 +3011,7 @@ class DotWriter:
             MAX_FUNCTION_NAME = 4096
             if len(function_name) >= MAX_FUNCTION_NAME:
                 sys.stderr.write('warning: truncating function name with %u chars (%s)\n' % (len(function_name), function_name[:32] + '...'))
-                function_name = function_name[:MAX_FUNCTION_NAME - 1] + unichr(0x2026)
+                function_name = function_name[:MAX_FUNCTION_NAME - 1] + ELLIPSIS 
 
             if self.wrap:
                 function_name = self.wrap_function_name(function_name)

--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -32,6 +32,7 @@ import collections
 import locale
 import json
 import fnmatch
+import tempfile
 
 # Python 2.x/3.x compatibility
 if sys.version_info[0] >= 3:
@@ -48,14 +49,22 @@ else:
     def compat_itervalues(x): return x.itervalues()
     def compat_keys(x): return x.keys()
 
-
-
-########################################################################
+##################################################################
 # Model
 
 
 MULTIPLICATION_SIGN = unichr(0xd7)
 ELLIPSIS = unichr(0x2026)
+try:
+    tempfile.TemporaryFile(mode="w").write(MULTIPLICATION_SIGN)
+    SYSTEM_SUPPORTS_UNICODE = True
+except UnicodeEncodeError as e:
+    SYSTEM_SUPPORTS_UNICODE = False
+    unichr = lambda c : "0x%02x" % int(c)
+    MULTIPLICATION_SIGN = "x"
+    ELLIPSIS = "..."
+finally:
+    pass
 
 
 def times(x):

--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -61,7 +61,7 @@ try:
 except UnicodeEncodeError as e:
     SYSTEM_SUPPORTS_UNICODE = False
     unichr = lambda c : "0x%02x" % int(c)
-    MULTIPLICATION_SIGN = "x"
+    MULTIPLICATION_SIGN = "\\x"
     ELLIPSIS = "..."
 finally:
     pass

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ from setuptools import setup
 
 setup(
     name='gprof2dot',
-    version='2017.09.19',
+    version='2018.08.16',
     author='Jose Fonseca',
     author_email='jose.r.fonseca@gmail.com',
     url='https://github.com/jrfonseca/gprof2dot',


### PR DESCRIPTION
Resolves https://github.com/jrfonseca/gprof2dot/issues/47 which occurs when using the tool in docker containers.

Of course you could also install a unicode codec in the docker container...