### PR TITLE
Convert setup.py to setup.cfg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,4 +44,5 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
         python -m build
+        twine check --strict dist/*
         twine upload dist/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist
+        python -m build
         twine upload dist/*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-include README.md
-include LICENSE.txt

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ implemented, and I might be slow processing issue reports or pull requests.
 This is the result from the [example data](http://linuxgazette.net/100/misc/vinayak/overall-profile.txt) in the [Linux Gazette article](http://linuxgazette.net/100/vinayak.html) with the default settings:
 
 <!-- pngquant --speed=1 --ordered  --quality 0-85 ... -->
-![Sample](sample.png)
+![Sample](https://raw.githubusercontent.com/jrfonseca/gprof2dot/cf98cc0b5eae9fcb896a6f92e9bc2bcb27666515/sample.png)
 
 # Requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+[metadata]
+name = gprof2dot
+version = 2022.01.31
+author = Jose Fonseca
+author_email = jose.r.fonseca@gmail.com
+url = https://github.com/jrfonseca/gprof2dot
+description = Generate a dot graph from the output of several profilers.
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = LGPL
+classifiers =
+    Development Status :: 6 - Mature
+    Environment :: Console
+    Intended Audience :: Developers
+    Operating System :: OS Independent
+    License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Topic :: Software Development
+
+[options]
+py_modules = gprof2dot
+python_requires = >=2.7
+
+[options.entry_points]
+console_scripts =
+    gprof2dot = gprof2dot:main
+
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,50 +1,5 @@
 #!/usr/bin/env python3
-#
-# The purpose of this script is to enable uploading gprof2dot.py to the Python
-# Package Index, which can be easily done by doing:
-#
-#   python3 setup.py sdist upload
-#
-# See also:
-# - https://packaging.python.org/distributing/
-# - https://docs.python.org/3/distutils/packageindex.html
-#
 
 from setuptools import setup
 
-setup(
-    name='gprof2dot',
-    version='2021.02.21',
-    author='Jose Fonseca',
-    author_email='jose.r.fonseca@gmail.com',
-    url='https://github.com/jrfonseca/gprof2dot',
-    description="Generate a dot graph from the output of several profilers.",
-    long_description="""
-        gprof2dot.py is a Python script to convert the output from many
-        profilers into a dot graph.
-        """,
-    license="LGPL",
-
-    py_modules=['gprof2dot'],
-    entry_points=dict(console_scripts=['gprof2dot=gprof2dot:main']),
-
-    # https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    classifiers=[
-        'Development Status :: 6 - Mature',
-
-        'Environment :: Console',
-
-        'Intended Audience :: Developers',
-
-        'Operating System :: OS Independent',
-
-        'License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)',
-
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-
-        'Topic :: Software Development',
-    ],
-)
+setup()


### PR DESCRIPTION
Refer to [setuptools' declarative configuration page](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html) for moving the static metadata into `setup.cfg`. The long description was modified to use README.md, which means that the PyPI page will show the same help as GitHub. All other metadata remains the same, so it's a close 1:1 conversion.

To build and upload:
```
$ pip install --upgrade build twine
...
$ python -m build
...
Successfully built gprof2dot-2022.1.31.tar.gz and gprof2dot-2022.1.31-py3-none-any.whl
$ twine upload --repository testpypi dist/*
...
```
View at:
https://test.pypi.org/project/gprof2dot/2022.1.31/

A few other notes:
- Now `setup.py` is a simple wrapper, which some folks expect to see; it may go away someday
- `MANIFEST.in` was removed, as the files were included anyways