### PR TITLE
Make GitHub Actions cover oldest and youngest Pythons alive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.8', '3.12']  # oldest and youngest Pythons alive
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/testOnly.yml
+++ b/.github/workflows/testOnly.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.8', '3.12']  # oldest and youngest Pythons alive
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
For your consideration :pray: 

For an overview of Pythons alive:
https://endoflife.date/python