### PR TITLE
Stop Codecov CI from failing on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
         pip install coverage
     - run: python tests/test.py --coverage
     - uses: codecov/codecov-action@v4
+      if: github.repository == 'jrfonseca/gprof2dot'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
For your consideration :pray: 

Symptom was:
```
Codecov: Failed to properly create commit: The process '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```