### PR TITLE
Drop Python 2.7 leftovers + require Python >=3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This is the result from the [example data](https://linuxgazette.net/100/misc/vin
 
 # Requirements
 
-  * [Python](https://www.python.org/download/): known to work with version 2.7 and 3.3; it will most likely _not_ work with earlier releases.
+  * [Python](https://www.python.org/download/): known to work with version >=3.8; it will most likely _not_ work with earlier releases.
   * [Graphviz](https://www.graphviz.org/Download.php): tested with version 2.26.3, but should work fine with other versions.
 
 ## Windows users

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 
 [options]
 py_modules = gprof2dot
-python_requires = >=2.7
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
For your consideration :pray: 

Support for Python 2.7 was dropped in commit 40e11273355f95dc8c56f51b77b29195608109be of release 2024.06.05.