### PR TITLE
reject negative cost and call counts in callgrind parser

### DIFF
--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -1791,6 +1791,15 @@ class CallgrindParser(LineParser):
         if not mo:
             return False
 
+        values = line.split()
+
+        # Costs are non-negative integer event counts.  Position columns may
+        # be relative (signed) or hexadecimal, but cost columns may not, so a
+        # line that smuggles such a token into a cost column is malformed and
+        # must not be allowed to skew the totals.
+        if not all(value.isdigit() for value in values[self.num_positions:]):
+            return False
+
         function = self.get_function()
 
         if calls is None:
@@ -1802,7 +1811,6 @@ class CallgrindParser(LineParser):
             except KeyError:
                 pass
 
-        values = line.split()
         assert len(values) <= self.num_positions + self.num_events
 
         positions = values[0 : self.num_positions]
@@ -1851,6 +1859,10 @@ class CallgrindParser(LineParser):
 
         _, values = line.split('=', 1)
         values = values.strip().split()
+        # The call count is a non-negative integer; reject a malformed or
+        # negative count rather than letting it through as a bogus tally.
+        if not values or not values[0].isdigit():
+            return False
         calls = int(values[0])
         call_position = values[1:]
         self.consume()


### PR DESCRIPTION
CallgrindParser.parse_cost_line reuses the subposition pattern for the cost columns, so a cost written as a relative or signed token slips through even though callgrind costs are non-negative integer event counts. A file with a line like `0 -90` feeds that negative value straight into the per-function and global SAMPLES totals, which deflates the denominator and pushes the other functions well past their real share of time (and silently drops the tampered function). parse_association_spec has the same gap, taking the `calls=` count through a bare int(), so `calls=-5` lands as a negative call tally on the node and edge.

Validate that the cost columns and the call count are non-negative integers and treat a line that violates that as unrecognized, the same way the parser already handles any other malformed line. Keeping the check inside the parser means a crafted profile cannot skew the totals before the rest of the pipeline sees them, and it matches the non-negative form the cost regex and the existing _call_re already describe.