### PR TITLE
reject non-finite cost values in json parser

### DIFF
--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -876,9 +876,21 @@ class JsonParser(Parser):
         Parser.__init__(self)
         self.stream = stream
 
+    @staticmethod
+    def _reject_constant(token):
+        # NaN/Infinity are not valid JSON (schema.json defines costs as finite
+        # numbers), but Python's json module accepts them as an extension. A
+        # non-finite cost poisons the SAMPLES total and every derived ratio, so
+        # refuse the tokens instead of accepting them.
+        raise ValueError('invalid JSON token %r' % token)
+
     def parse(self):
 
-        obj = json.load(self.stream)
+        try:
+            obj = json.load(self.stream, parse_constant=self._reject_constant)
+        except ValueError as ex:
+            sys.stderr.write('error: %s\n' % ex)
+            sys.exit(1)
 
         assert obj['version'] == 0
 


### PR DESCRIPTION
    ValueError: cannot convert float NaN to integer

A JSON profile whose cost is `NaN` or `Infinity` reaches this, since json.load accepts those tokens as an extension even though schema.json defines costs as finite numbers. The non-finite value lands in the per-function and global SAMPLES totals, so one crafted event poisons the denominator of every ratio (other functions collapse to 0%) and NaN then propagates into color() and aborts the run. Reject the tokens with a parse_constant callback so the profile is refused at load instead.