### PR TITLE
quote dot reserved keywords used as node identifiers

### DIFF
--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -3405,11 +3405,14 @@ class DotWriter:
             id = '_' + hashlib.sha1(id.encode('utf-8'), usedforsecurity=False).hexdigest()
         self.id(id)
 
+    # dot keywords, which must be quoted when used as ordinary identifiers.
+    _keywords = frozenset(('node', 'edge', 'graph', 'digraph', 'subgraph', 'strict'))
+
     def id(self, id):
         if isinstance(id, (int, float)):
             s = str(id)
         elif isinstance(id, str):
-            if id.isalnum() and not id.startswith('0x'):
+            if id.isalnum() and not id.startswith('0x') and id.lower() not in self._keywords:
                 s = id
             else:
                 s = self.escape(id)

--- a/tests/collapse/keywords.collapse
+++ b/tests/collapse/keywords.collapse
@@ -1,0 +1,4 @@
+main;graph;node 30
+main;graph;edge 20
+main;graph;subgraph 10
+main;strict 5


### PR DESCRIPTION
`DotWriter.id` writes any all-alphanumeric string unquoted, but dot reserves `node`, `edge`, `graph`, `digraph`, `subgraph` and `strict` as keywords. A profiled function named after one of these (common in graph, tree, and parser code) lands as a bare keyword where a node id belongs, so dot either aborts with a syntax error or silently reads the line as a default-attribute statement, which drops the node and overrides the whole graph's styling.

Excluding those names from the unquoted fast path sends them through `escape()` so they come out quoted. Keeping the check in `id()` covers node ids, edge endpoints, and attribute values in one place rather than at every call site. The added collapse fixture has a stack named after the keywords; dot rejects the current output for it and renders it once the names are quoted.