### PR TITLE
fix --compare crash on functions missing from the second profile

### DIFF
--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -3129,6 +3129,7 @@ class DotWriter:
 
         for _, function1 in sorted_iteritems(profile1.functions):
             labels = []
+            function2 = None
 
             name = function1.name
             try:
@@ -3238,7 +3239,10 @@ class DotWriter:
                       tooltip=function1.filename,
                       )
 
-            calls2 = {call.callee_id: call for _, call in sorted_iteritems(function2.calls)}
+            if function2 is not None:
+                calls2 = {call.callee_id: call for _, call in sorted_iteritems(function2.calls)}
+            else:
+                calls2 = {}
             functions_by_id1 = {function.id: function for _, function in sorted_iteritems(profile1.functions)}
 
             for _, call1 in sorted_iteritems(function1.calls):

--- a/tests/compare/callgrind/unmatched/unmatched1.callgrind
+++ b/tests/compare/callgrind/unmatched/unmatched1.callgrind
@@ -1,0 +1,14 @@
+# callgrind format
+version: 1
+creator: test
+positions: line
+events: Ir
+
+fn=extra_helper
+0 10
+cfn=main
+calls=1 0
+0 4
+
+fn=main
+0 7

--- a/tests/compare/callgrind/unmatched/unmatched2.callgrind
+++ b/tests/compare/callgrind/unmatched/unmatched2.callgrind
@@ -1,0 +1,8 @@
+# callgrind format
+version: 1
+creator: test
+positions: line
+events: Ir
+
+fn=main
+0 7


### PR DESCRIPTION
graphs_compare binds function2 only inside the try branch that runs when function1 is also present in the second profile. When a function exists only in the first profile the except branch runs and never sets function2, so the calls2 comprehension further down reads a stale function2 left from an earlier iteration, or raises UnboundLocalError on the first function processed. Comparing two profiles whose function sets differ is the ordinary case for --compare, so this fires on normal runs rather than crafted input.

Reset function2 to None at the top of each iteration and use an empty calls2 when there is no match. An unmatched function's edges then fall through to the same single-value labels its own node already gets, instead of borrowing another function's call data. Keeping the fallback next to the comprehension leaves the edge loop reading a consistent map.