### PR TITLE
quote dot node identifiers that begin with a digit

### DIFF
--- a/gprof2dot.py
+++ b/gprof2dot.py
@@ -3424,7 +3424,7 @@ class DotWriter:
         if isinstance(id, (int, float)):
             s = str(id)
         elif isinstance(id, str):
-            if id.isalnum() and not id.startswith('0x') and id.lower() not in self._keywords:
+            if id.isalnum() and not id[0].isdigit() and id.lower() not in self._keywords:
                 s = id
             else:
                 s = self.escape(id)

--- a/tests/collapse/digits.collapse
+++ b/tests/collapse/digits.collapse
@@ -1,0 +1,3 @@
+main;3d 30
+main;1e5 20
+main;123abc 10


### PR DESCRIPTION
id() only quotes identifiers that aren't plain alphanumeric, with one narrow exception for the `0x` hex-address prefix. Any other alphanumeric name that starts with a digit still goes out unquoted, so a function or module named like `3d`, `1e5` or `123abc` lands unquoted where a dot node id belongs. dot lexes a digit-leading token as a numeral, so `3d` splits into `3` and `d`: the node declaration and the edges referencing it resolve to different phantom nodes, and the real node is dropped or mislabeled.

Widen the existing `0x` guard to reject any identifier whose first character is a digit, routing these names through the quoted path. Keeping the check in id() covers every node id, edge endpoint and label from the single place they are all written. Pure integers get quoted too, which is harmless since a declaration and its references stay consistent.